### PR TITLE
charlotte: overlay: set higher status bar height

### DIFF
--- a/overlay/frameworks/base/core/res/res/values-land/dimens.xml
+++ b/overlay/frameworks/base/core/res/res/values-land/dimens.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/* //device/apps/common/assets/res/any/dimens.xml
+**
+** Copyright 2006, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<resources>
+    <!-- Height of the status bar -->
+    <dimen name="status_bar_height">24dp</dimen>
+</resources>

--- a/overlay/frameworks/base/core/res/res/values/dimens.xml
+++ b/overlay/frameworks/base/core/res/res/values/dimens.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/* //device/apps/common/assets/res/any/dimens.xml
+**
+** Copyright 2006, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<resources>
+    <!-- Height of the status bar -->
+    <dimen name="status_bar_height">82px</dimen>
+</resources>


### PR DESCRIPTION
This will help a bit on getting a proper status bar size to match the notch.

Signed-off-by: Hernán Castañón <herna@paranoidandroid.co>